### PR TITLE
Multitable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 ### Parquet file explorer
+
+Command line parquet file explorer. Built with Rust, Clap, Arrow and Dataflow.
+
+### Build
+
+$ cargo build --release
+
+### Local testing through cargo
+
+$ cargo run -- -f <file.parquet> -d
+
+### Options
+	- -d (--describe) show table structure
+	- -f <filename> (--file <filename>) parquet file 
+	- -q <query> (--query <query>)  "SELECT * FROM tablename", tablename is the filename w/o extension
+
+

--- a/src/TODO
+++ b/src/TODO
@@ -1,4 +1,2 @@
-- split files
-- add multifile/multitable support
 - add a REPL
 - enable saving a resultset(dataframe) as a new parquet file

--- a/src/TODO
+++ b/src/TODO
@@ -1,0 +1,4 @@
+- split files
+- add multifile/multitable support
+- add a REPL
+- enable saving a resultset(dataframe) as a new parquet file

--- a/src/filemanager.rs
+++ b/src/filemanager.rs
@@ -1,0 +1,57 @@
+use datafusion;
+use std::path::{PathBuf,Path};
+use std::collections::HashMap;
+use std::fs;
+
+//#[derive(Clone)]
+pub struct ParquetFileManager{
+    pub root_path: String,
+    pub path: PathBuf,
+    pub execution_context: datafusion::prelude::ExecutionContext,
+    pub files: HashMap<String, String>,
+}
+
+impl ParquetFileManager {
+    fn load_parquet(&mut self, pathname: String) {
+        let path = Path::new(&pathname);
+        let tablename = path.file_stem().unwrap().to_str().unwrap();
+
+        self.execution_context.register_parquet(&tablename.clone(), &pathname).unwrap();
+        self.files.insert(tablename.to_string(), pathname);
+    }
+
+    fn load_files(&mut self) {
+        let dir = &self.path;
+        if dir.is_dir() {
+            // directory with one or more files
+            for entry in fs::read_dir(dir).unwrap() {
+                let path = entry.unwrap().path();
+                if path.is_file() {
+                    let parquet_path = path.to_str().unwrap().to_string();
+                    self.load_parquet(parquet_path);
+                };
+            }
+        } else {
+            // single file
+            if self.path.is_file() {
+                let parquet_path = self.path.to_str().unwrap().to_string();
+                self.load_parquet(parquet_path);
+            };
+        }
+    }
+
+    pub fn new (basepath:  String) -> Self {
+        let bp = Path::new(&basepath);
+        let execution_config = datafusion::prelude::ExecutionConfig::new().with_information_schema(true);
+
+        let mut s = Self {
+            root_path: basepath.clone(),
+            files: HashMap::new(),
+            path: bp.to_path_buf(),
+            execution_context: datafusion::prelude::ExecutionContext::with_config(execution_config),
+        };
+
+        s.load_files();
+        return s
+    }
+}

--- a/src/filemanager.rs
+++ b/src/filemanager.rs
@@ -1,10 +1,10 @@
 use datafusion;
-use std::path::{PathBuf,Path};
 use std::collections::HashMap;
 use std::fs;
+use std::path::{Path, PathBuf};
 
-//#[derive(Clone)]
-pub struct ParquetFileManager{
+#[derive(Clone)]
+pub struct ParquetFileManager {
     pub root_path: String,
     pub path: PathBuf,
     pub execution_context: datafusion::prelude::ExecutionContext,
@@ -16,7 +16,9 @@ impl ParquetFileManager {
         let path = Path::new(&pathname);
         let tablename = path.file_stem().unwrap().to_str().unwrap();
 
-        self.execution_context.register_parquet(&tablename.clone(), &pathname).unwrap();
+        self.execution_context
+            .register_parquet(&tablename.clone(), &pathname)
+            .unwrap();
         self.files.insert(tablename.to_string(), pathname);
     }
 
@@ -40,9 +42,10 @@ impl ParquetFileManager {
         }
     }
 
-    pub fn new (basepath:  String) -> Self {
+    pub fn new(basepath: String) -> Self {
         let bp = Path::new(&basepath);
-        let execution_config = datafusion::prelude::ExecutionConfig::new().with_information_schema(true);
+        let execution_config =
+            datafusion::prelude::ExecutionConfig::new().with_information_schema(true);
 
         let mut s = Self {
             root_path: basepath.clone(),
@@ -52,6 +55,6 @@ impl ParquetFileManager {
         };
 
         s.load_files();
-        return s
+        return s;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
-use arrow::record_batch::RecordBatch;
-use arrow::util::pretty::print_batches;
 use clap::{AppSettings, Clap};
-use std::time::Instant;
-use datafusion;
 
 
 mod filemanager;
+mod parquethandler;
 
 #[derive(Clap)]
 #[clap(version = "0.0.1", author = "gleicon <gleicon@gmail.com>")]
@@ -25,41 +22,16 @@ struct Opts {
 pub async fn main() {
     let opts: Opts = Opts::parse();
     let pm = filemanager::ParquetFileManager::new(opts.file.clone());
-    let ctx = pm.execution_context;
+    let parquet_handler = parquethandler::ParquetHandler::new(pm);
 
     if opts.describe {
-        for (k, _v) in pm.files.iter() {
-            let qq = format!("SHOW COLUMNS FROM {}", k);
-            query_parquet(ctx.clone(), qq).await.unwrap()
-        }
-        
+        parquet_handler.clone().describe().await;
     }
 
     match opts.query {
         Some(q) => {
-            match query_parquet(ctx.clone(), q.clone()).await {
-                Ok(_a) => (),
-                Err(e) => println!("Error running query {:?}: {:?}", q, e),
-            }
+            parquet_handler.clone().query(q).await.unwrap();
         },
         None => println!("Empty query"), 
-    }
-}
-
-
-async fn query_parquet(mut ctx: datafusion::prelude::ExecutionContext, query: String) -> datafusion::error::Result<()> {
-    let start = Instant::now();
-
-    println!("query: {}", query);
-    // cargo run -- -d -f test_data/taxi_2019_04.parquet -q "SELECT count(*) FROM parquet_tables"
-    match ctx.sql(&query) {
-        Ok(df) => {
-            let results: Vec<RecordBatch> = df.collect().await.unwrap();
-            print_batches(&results).unwrap();
-            let duration = start.elapsed();
-            println!("Time elapsed: {:?}\n{:?} rows", duration, results.len());
-            return Ok(())
-        },
-        Err(e) => return Err(e),
     }
 }

--- a/src/parquethandler.rs
+++ b/src/parquethandler.rs
@@ -1,0 +1,44 @@
+
+use std::time::Instant;
+use arrow::record_batch::RecordBatch;
+use arrow::util::pretty::print_batches;
+
+#[derive(Clone)]
+pub struct ParquetHandler {
+    pub pm: crate::filemanager::ParquetFileManager,
+    pub ctx: datafusion::prelude::ExecutionContext, // shortcut
+}
+
+impl ParquetHandler {
+    pub async fn describe(&mut self){
+        for (k, _v) in self.pm.files.iter() {
+            let qq = format!("SHOW COLUMNS FROM {}", k.clone());
+            self.clone().query(qq).await.unwrap()
+        }
+    }
+
+    pub async fn query(&mut self, query: String) -> datafusion::error::Result<()> {
+        let start = Instant::now();
+    
+        println!("query: {}", query);
+        // cargo run -- -d -f test_data/taxi_2019_04.parquet -q "SELECT count(*) FROM parquet_tables"
+        match self.ctx.sql(&query) {
+            Ok(df) => {
+                let results: Vec<RecordBatch> = df.collect().await.unwrap();
+                print_batches(&results).unwrap();
+                let duration = start.elapsed();
+                println!("Time elapsed: {:?}\n{:?} rows", duration, results.len());
+                return Ok(())
+            },
+            Err(e) => return Err(e),
+        }
+    }
+    
+    pub fn new(pm: crate::filemanager::ParquetFileManager) -> Self {
+        let s = Self {
+            pm: pm.clone(),
+            ctx: pm.execution_context,
+        };
+        return s
+    }
+}


### PR DESCRIPTION
FIrst part of multitable support is there - parquet-explorer either reads a single file or a folder with one or more files. Big refactoring to separate concerns into handlers and managers with dependency injection.